### PR TITLE
Using scheme-less URL for urlShortener service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # trifid-plugin-yasgui
 
 YASGUI for Trifid.
-This middleware does the static file hosting for all YASGUI files and renders a index page that points to the given endpoint URL.
+This middleware does the static file hosting for all YASGUI files and renders an index page that points to the given endpoint URL.
  
 # Usage
 
 The following options are supported:
 
 - `endpointUrl`: URL to the SPARQL endpoint which will be used in the YASGUI interface
-- `template`: Path to an alternative template (default: `templates/index.html`)
+- `template`: Path to an alternative template (default: `views/index.html`)
+
+An example for a customized trifid configuration using an alternative template looks like this:
+
+	{
+	  ...
+	  "yasgui" : {
+	    "default": {
+	      "template": "cwd:views/yasgui.html"
+	    }
+	  },
+	  ...
+	}

--- a/views/index.html
+++ b/views/index.html
@@ -25,7 +25,7 @@ ${include('cwd:views/footer.html')}
 <script type="text/javascript">
    // set SPARQL endpoint URL
    YASGUI.defaults.yasqe.sparql.endpoint = '${endpointUrl}'
-   var config = {"api":{"urlShortener":"http://yasgui.org/shorten"}}
+   var config = {"api":{"urlShortener":"//yasgui.org/shorten"}}
    var yasgui = YASGUI(document.getElementById('yasgui'), config)
 </script>
 


### PR DESCRIPTION
By using a scheme-less URL for the urlShortener service, shortening URLs in YASGUI also works for domains served over HTTPS.

For details, see also: https://github.com/statistikstadtzuerich/ld.stadt-zuerich.ch/issues/27

